### PR TITLE
Small fix for CodeConnectFix

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -128,16 +128,16 @@ class WSClient extends EventEmitter {
 
     sendFrame(messagePurpose, body, requestId, extraHeaders) {
         this.sendMessage({
-            header: buildHeader(messagePurpose, requestId, extraHeaders),
+            header: buildHeader(messagePurpose, requestId, this.version, extraHeaders),
             body
         });
     }
 
-    sendError(statusCode, statusMessage) {
+    sendError(statusCode, statusMessage, requestId) {
         this.sendFrame("error", {
             statusCode,
             statusMessage
-        });
+        }, requestId);
     }
 
     sendEvent(eventName, body) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -26,7 +26,7 @@ function onMessage(messageData) {
     switch (purpose) {
         case "event":
         case "chat":
-            if (version === V2) {
+            if (version >= V2) {
                 this.publishEvent(header.eventName, {
                     ...frameBase,
                     eventName: header.eventName


### PR DESCRIPTION
Hi, 

I have made a tools call [CodeConnectFix](https://github.com/lrocher/CodeConnectFix) with your library for fix a connection issue between 'Code Connection for Minecraft' and last Minecraft Bedrock version.

(See comment)[https://educommunity.minecraft.net/hc/en-us/community/posts/5757924107284-Code-connection-error]

I had to make some small corrections for it to work correctly. 

- Client.sendFrame : Fix missing version  parameter in buildHeader
- Client.sendError: Allow specify a requestId
- Server.onMessage: Use same publishEvent format for all version greater than V2

Regards